### PR TITLE
Install/win: Fix Appveyor build script

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,11 +29,11 @@ install:
   - conda config --set always_yes yes --set changeps1 no
   - conda update -q conda
   - conda info -a
+  - conda install vtk=8.1.0
+  - python -m pip install --upgrade pip
   - python setup.py install
   - python -m PVGeo install echo
-  - python -m pip install --upgrade pip
   - pip install -r requirements_win.txt
-  - conda install vtk=8.1.0
 
 
 test_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -31,6 +31,7 @@ install:
   - conda info -a
   - python setup.py install
   - python -m PVGeo install echo
+  - python -m pip install --upgrade pip
   - pip install -r requirements_win.txt
   - conda install vtk=8.1.0
 

--- a/requirements_win.txt
+++ b/requirements_win.txt
@@ -1,4 +1,4 @@
-numpy==1.13
+numpy>=1.13
 scipy>=1.1
 colour-runner==0.0.5
 codecov==2.0.15

--- a/tests/readers_test.py
+++ b/tests/readers_test.py
@@ -60,14 +60,14 @@ class TestDelimitedTextReader(unittest.TestCase):
         self.assertEqual(table.GetColumnName(2), titles[2])
         return
 
-    def _check_array_types(self, table, types=[int, float, float]):
+    def _check_array_types(self, table, types=[16, 13, 11]):
         # Check data array types:
         typ = table.GetColumn(0).GetDataType()
-        self.assertEqual(typ, nps.get_vtk_array_type(int))
+        self.assertEqual(typ, types[0])
         typ = table.GetColumn(1).GetDataType()
-        self.assertEqual(typ, 13)
+        self.assertEqual(typ, types[1])
         typ = table.GetColumn(2).GetDataType()
-        self.assertEqual(typ, nps.get_vtk_array_type(float))
+        self.assertEqual(typ, types[2])
         return
 
     def _check_array_values(self, table):


### PR DESCRIPTION
Implement fixes to the Appveyor build script. 

There were some VERY strange errors with virtual environments (specifying py36 and getting py37) so I set up the script to force a downgrade.

Windows testing is good to go!