### PR TITLE
Better Table to Grid

### DIFF
--- a/PVGeo/filters/tables.py
+++ b/PVGeo/filters/tables.py
@@ -192,6 +192,7 @@ class ReshapeTable(FilterBase):
             self.Modified()
 
 
+###############################################################################
 
 class ExtractArray(FilterBase):
     """Extract an array from a ``vtkDataSet`` and make a ``vtkTable`` of it.

--- a/PVGeo/grids/table2grid.py
+++ b/PVGeo/grids/table2grid.py
@@ -1,5 +1,6 @@
 __all__ = [
     'TableToGrid',
+    'TableToTimeGrid',
 ]
 
 import vtk
@@ -15,7 +16,18 @@ from .. import interface
 
 
 class TableToGrid(FilterBase):
-    """This filter takes a ``vtkTable`` object with columns that represent data to be translated (reshaped) into a 3D grid (2D also works, just set the third dimensions extent to 1). The grid will be a ``n1`` by ``n2`` by ``n3`` ``vtkImageData`` structure and an origin (south-west bottom corner) can be set at any xyz point. Each column of the ``vtkTable`` will represent a data attribute of the ``vtkImageData`` formed (essentially a uniform mesh). The SEPlib option allows you to unfold data that was packed in the SEPlib format where the most important dimension is z and thus the z data is d1 (``d1=z``, ``d2=y``, ``d3=x``). When using SEPlib, specify ``n1`` as the number of elements in the Z-direction, ``n2`` as the number of elements in the X-direction, and ``n3`` as the number of elements in the Y-direction (and so on for other parameters).
+    """This filter takes a ``vtkTable`` object with columns that represent data
+    to be translated (reshaped) into a 3D grid (2D also works, just set the
+    third dimensions extent to 1). The grid will be a ``n1`` by ``n2`` by ``n3``
+    ``vtkImageData`` structure and an origin (south-west bottom corner) can be
+    set at any xyz point. Each column of the ``vtkTable`` will represent a data
+    attribute of the ``vtkImageData`` formed (essentially a uniform mesh).
+    The SEPlib option allows you to unfold data that was packed in the SEPlib
+    format where the most important dimension is z and thus the z data is d1
+    (``d1=z``, ``d2=y``, ``d3=x``). When using SEPlib, specify ``n1`` as the
+    number of elements in the Z-direction, ``n2`` as the number of elements in
+    the X-direction, and ``n3`` as the number of elements in the Y-direction
+    (and so on for other parameters).
 
     Warning:
         **Work in progress**
@@ -37,9 +49,9 @@ class TableToGrid(FilterBase):
 
     @staticmethod
     def _unpack(arr, extent, order='C'):
-        """This is a helper method that handles the initial unpacking of a data array.
-        ParaView and VTK use Fortran packing so this is convert data saved in
-        C packing to Fortran packing.
+        """This is a helper method that handles the initial unpacking of a data
+        array. ParaView and VTK use Fortran packing so this is convert data
+        saved in C packing to Fortran packing.
         """
         n1,n2,n3 = extent[0],extent[1],extent[2]
         if order == 'C':
@@ -54,7 +66,8 @@ class TableToGrid(FilterBase):
 
     @staticmethod
     def _rearangeSEPlib(arr, extent):
-        """This is a helper method to swap axes when using SEPlib axial conventions.
+        """This is a helper method to swap axes when using SEPlib axial
+        conventions.
         """
         n1,n2,n3 = extent[0],extent[1],extent[2]
         arr = np.reshape(arr, (n3,n2,n1))
@@ -79,7 +92,8 @@ class TableToGrid(FilterBase):
 
     @staticmethod
     def _refold(arr, extent, SEPlib=True, order='F', swapXY=False):
-        """This is a helper method to handle grabbing a data array and make sure it is ready for VTK/Fortran ordering in ``vtkImageData``.
+        """This is a helper method to handle grabbing a data array and make
+        sure it is ready for VTK/Fortran ordering in ``vtkImageData``.
         """
         # Fold into 3D using extents. Packing dimensions should be in order extent
         arr, extent = TableToGrid._unpack(arr, extent, order=order)
@@ -91,7 +105,8 @@ class TableToGrid(FilterBase):
 
     @staticmethod
     def RefoldIdx(SEPlib=True, swapXY=False):
-        """Theses are indexing corrections to set the spacings and origin witht the correct axes after refolding.
+        """Theses are indexing corrections to set the spacings and origin witht
+        the correct axes after refolding.
         """
         if SEPlib:
             idx = (2,1,0)
@@ -104,8 +119,9 @@ class TableToGrid(FilterBase):
         return idx
 
     def _TableToGrid(self, pdi, ido):
-        """Converts a table of data arrays to vtkImageData given an extent to reshape that table.
-        Each column in the table will be treated as seperate data arrays for the described data space.
+        """Converts a table of data arrays to vtkImageData given an extent to
+        reshape that table. Each column in the table will be treated as seperate
+        data arrays for the described data space.
         """
         cols = pdi.GetNumberOfColumns()
         rows = pdi.GetColumn(0).GetNumberOfTuples()
@@ -137,6 +153,9 @@ class TableToGrid(FilterBase):
 
         return ido
 
+
+    #### Algorithm Methods ####
+
     def RequestData(self, request, inInfo, outInfo):
         """Used by pipeline to generate output"""
         # Get input/output of Proxy
@@ -148,8 +167,7 @@ class TableToGrid(FilterBase):
 
 
     def RequestInformation(self, request, inInfo, outInfo):
-        """Used by pipeline to set whole output extent.
-        """
+        """Used by pipeline to set whole output extent."""
         # Setup the ImageData
         idx = TableToGrid.RefoldIdx(SEPlib=self.__SEPlib, swapXY=self.__swapXY)
         ext = [0, self.__extent[idx[0]]-1, 0,self.__extent[idx[1]]-1, 0,self.__extent[idx[2]]-1]
@@ -169,22 +187,19 @@ class TableToGrid(FilterBase):
             self.Modified()
 
     def SetSpacing(self, dx, dy, dz):
-        """Set the spacing for the points along each axial direction
-        """
+        """Set the spacing for the points along each axial direction"""
         if self.__spacing != [dx, dy, dz]:
             self.__spacing = [dx, dy, dz]
             self.Modified()
 
     def SetOrigin(self, x0, y0, z0):
-        """Set the origin of the output `vtkImageData`
-        """
+        """Set the origin of the output `vtkImageData`"""
         if self.__origin != [x0, y0, z0]:
             self.__origin = [x0, y0, z0]
             self.Modified()
 
     def SetSEPlib(self, flag):
-        """Set a flag to swap the axial order for the refold of the table
-        """
+        """Set a flag to swap the axial order for the refold of the table"""
         if self.__SEPlib != flag:
             self.__SEPlib = flag
             self.Modified()
@@ -196,8 +211,166 @@ class TableToGrid(FilterBase):
             self.Modified()
 
     def SetSwapXY(self, flag):
-        """Set a flag to swap the X and Y axii
-        """
+        """Set a flag to swap the X and Y axii"""
         if self.__swapXY != flag:
             self.__swapXY = flag
             self.Modified()
+
+
+
+
+###############################################################################
+
+class TableToTimeGrid(FilterBase):
+    """A filter to convert a static (no time variance) table to a time varying
+    grid. This effectively reashapes a table full of data arrays as a 4D array
+    that is place on to ``vtkImageData``.
+    """
+    __displayname__ = 'Table To Time Grid'
+    __category__ = 'filter'
+    def __init__(self, extent=[10, 10, 10, 1], order='C', spacing=[1.0, 1.0, 1.0],
+                 origin=[0.0, 0.0, 0.0], dims=[0, 1, 2, 3], dt=1.0, **kwargs):
+        FilterBase.__init__(self, nInputPorts=1, nOutputPorts=1,
+                inputType='vtkTable', outputType='vtkImageData', **kwargs)
+        if len(extent) != 4:
+            raise _helpers.PVGeoError('`extent` must be of length 4.')
+        self.__extent = extent
+        self.__dims = dims # these are indexes for the filter to use on the reshape.
+        # NOTE: self.__dims[0] is the x axis index, etc., self.__dims[3] is the time axis
+        self.__spacing = spacing # image data spacing
+        self.__origin = origin # image data origin
+        self.__order = order # unpacking order: 'C' or 'F'
+        self.__data = None # this is where we hold the data so entire filter does
+        # not execute on every time step. Data will be a disctionary of 4D arrays
+        # each 4D array will be in (nx, ny, nz, nt) shape
+        self.__needToRun = True
+        self.__timesteps = None
+        self.__dt = dt
+
+
+    def _SetData(self, table):
+        self.__data = dict()
+        dims = [d for d in self.__dims]
+        df = interface.tableToDataFrame(table)
+        keys = df.keys().tolist()
+        for k in keys:
+            # perfrom the reshape properly.
+            arr = np.reshape(df[k].values, self.__extent, order=self.__order)
+            # Now order correctly for the image data spatial reference
+            for i in [0, 1, 2, 3]:
+                d = dims[i]
+                dims[d] = dims[i]
+                dims[i] = i
+                arr = arr.swapaxes(d, i)
+            # Now add to disctionary
+            self.__data[k] = arr
+        self.__needToRun = False
+        return
+
+    def _BuildImageData(self, img):
+        ext = self.__extent
+        dims = self.__dims
+        nx, ny, nz = ext[dims[0]], ext[dims[1]], ext[dims[2]]
+        sx, sy, sz = self.__spacing[0],self.__spacing[1],self.__spacing[2]
+        ox, oy, oz = self.__origin[0],self.__origin[1],self.__origin[2]
+        img.SetDimensions(nx, ny, nz)
+        img.SetSpacing(sx, sy, sz)
+        img.SetOrigin(ox, oy, oz)
+        return img
+
+    def _UpdateTimeSteps(self):
+        """For internal use only: appropriately sets the timesteps.
+        """
+        nt = self.__extent[self.__dims[3]]
+        if nt > 1:
+            self.__timesteps = _helpers.updateTimeSteps(self, nt, self.__dt)
+        return 1
+
+
+    #### Algorithm Methods ####
+
+    def RequestData(self, request, inInfo, outInfo):
+        """Used by pipeline to generate output"""
+        # Get input/output of Proxy
+        table = self.GetInputData(inInfo, 0, 0)
+        img = vtk.vtkImageData.GetData(outInfo, 0)
+        self._BuildImageData(img)
+        # Perfrom task
+        if self.__needToRun:
+            self._SetData(table)
+        # Get requested time index
+        i = _helpers.getRequestedTime(self, outInfo)
+        for k, arr in self.__data.items():
+            img.GetPointData().AddArray(
+                interface.convertArray(arr[:,:,:,i].flatten(order='F'), name=k)
+                )
+        return 1
+
+
+    def RequestInformation(self, request, inInfo, outInfo):
+        """Used by pipeline to set whole output extent."""
+        # Setup the ImageData
+        ext = self.__extent
+        dims = self.__dims
+        nx, ny, nz = ext[dims[0]], ext[dims[1]], ext[dims[2]]
+        ext = [0, nx-1, 0,ny-1, 0,nz-1]
+        info = outInfo.GetInformationObject(0)
+        # Set WHOLE_EXTENT: This is absolutely necessary
+        info.Set(vtk.vtkStreamingDemandDrivenPipeline.WHOLE_EXTENT(), ext, 6)
+        # Now set the number of timesteps:
+        self._UpdateTimeSteps()
+        return 1
+
+
+
+    #### Setters / Getters ####
+
+    def Modified(self, runAgain=True):
+        """Call modified if the filter needs to run again"""
+        if runAgain: self.__needToRun = runAgain
+        FilterBase.Modified(self)
+
+    def SetExtent(self, nx, ny, nz, nt):
+        """Set the extent of the output grid"""
+        if self.__extent != [nx, ny, nz, nt]:
+            self.__extent = [nx, ny, nz, nt]
+            self.Modified()
+
+    def SetDimensions(self, x, y, z, t):
+        if self.__dims != [x, y, z, t]:
+            self.__dims = [x, y, z, t]
+            self.Modified()
+
+    def SetSpacing(self, dx, dy, dz):
+        """Set the spacing for the points along each axial direction"""
+        if self.__spacing != [dx, dy, dz]:
+            self.__spacing = [dx, dy, dz]
+            self.Modified()
+
+    def SetOrigin(self, x0, y0, z0):
+        """Set the origin of the output `vtkImageData`"""
+        if self.__origin != [x0, y0, z0]:
+            self.__origin = [x0, y0, z0]
+            self.Modified()
+
+    def SetOrder(self, order):
+        """Set the reshape order (`'C'` or `'F'`)"""
+        if self.__order != order:
+            self.__order = order
+            self.Modified()
+
+    def GetTimestepValues(self):
+        """Use this in ParaView decorator to register timesteps on the pipeline.
+        """
+        return self.__timesteps.tolist() if self.__timesteps is not None else None
+
+    def SetTimeDelta(self, dt):
+        """An advanced property to set the time step in seconds.
+        """
+        if dt != self.__dt:
+            self.__dt = dt
+            self.Modified()
+
+
+
+###############################################################################

--- a/PVPlugins/PVGeo_Grid_Tools.py
+++ b/PVPlugins/PVGeo_Grid_Tools.py
@@ -105,6 +105,57 @@ class PVGeoTableToGrid(TableToGrid):
         TableToGrid.SetSwapXY(self, flag)
 
 
+###############################################################################
+
+
+@smproxy.filter(name='PVGeoTableToTimeGrid', label='Table To Time Grid')
+@smhint.xml('''<ShowInMenu category="%s"/>
+    <RepresentationType view="RenderView" type="Surface" />''' % MENU_CAT)
+@smproperty.input(name="Input", port_index=0)
+@smdomain.datatype(dataTypes=["vtkTable"], composite_data_supported=True)
+class PVGeoTableToGrid(TableToTimeGrid):
+    def __init__(self):
+        TableToTimeGrid.__init__(self)
+
+
+    #### Setters / Getters ####
+
+
+    @smproperty.intvector(name="Extent", default_values=[10, 10, 10, 1])
+    def SetExtent(self, nx, ny, nz, nt):
+        TableToTimeGrid.SetExtent(self, nx, ny, nz, nt)
+
+    @smproperty.intvector(name="Dimensions", default_values=[0, 1, 2, 3])
+    def SetDimensions(self, x, y, z, t):
+        TableToTimeGrid.SetDimensions(self, x, y, z, t)
+
+    @smproperty.doublevector(name="Spacing", default_values=[1.0, 1.0, 1.0])
+    def SetSpacing(self, dx, dy, dz):
+        TableToTimeGrid.SetSpacing(self, dx, dy, dz)
+
+    @smproperty.doublevector(name="Origin", default_values=[0.0, 0.0, 0.0])
+    def SetOrigin(self, x0, y0, z0):
+        TableToTimeGrid.SetOrigin(self, x0, y0, z0)
+
+
+    @smproperty.xml(_helpers.getDropDownXml(name='Order', command='SetOrder',
+        labels=['C-style: Row-major order', 'Fortran-style: column-major order'],
+        values=[0, 1]))
+    def SetOrder(self, order):
+        o = ['C', 'F']
+        TableToTimeGrid.SetOrder(self, o[order])
+
+    @smproperty.doublevector(name="TimeDelta", default_values=1.0, panel_visibility="advanced")
+    def SetTimeDelta(self, dt):
+        TableToTimeGrid.SetTimeDelta(self, dt)
+
+    @smproperty.doublevector(name="TimestepValues", information_only="1", si_class="vtkSITimeStepsProperty")
+    def GetTimestepValues(self):
+        """This is critical for registering the timesteps"""
+        return TableToTimeGrid.GetTimestepValues(self)
+
+
+
 
 ###############################################################################
 

--- a/tests/grids_test.py
+++ b/tests/grids_test.py
@@ -129,6 +129,58 @@ class TestTableToGrid(TestBase):
 
 ###############################################################################
 
+class TestTableToTimeGrid(TestBase):
+    """
+    Test the `TableToTimeGrid` filter
+    """
+    def setUp(self):
+        TestBase.setUp(self)
+        # Create some input tables
+        self.table = vtk.vtkTable()
+        # Populate the tables
+        self.arrs = [None, None, None]
+        self.n = 400
+        self.titles = ('Array 0', 'Array 1', 'Array 2')
+        self.arrs[0] = np.random.random(self.n)
+        self.arrs[1] = np.random.random(self.n)
+        self.arrs[2] = np.random.random(self.n)
+        self.table.AddColumn(interface.convertArray(self.arrs[0], self.titles[0]))
+        self.table.AddColumn(interface.convertArray(self.arrs[1], self.titles[1]))
+        self.table.AddColumn(interface.convertArray(self.arrs[2], self.titles[2]))
+        return
+
+    def check_data_fidelity(self, ido, checkme):
+        """`TableToTimeGrid`: data fidelity"""
+        wido = dsa.WrapDataObject(ido)
+        for i in range(len(self.titles)):
+            arr = wido.PointData[self.titles[i]]
+            self.assertTrue(np.allclose(arr, checkme[i], rtol=RTOL))
+
+    def test_simple(self):
+        """`TableToTimeGrid`: check simple"""
+        # Use filter
+        f = TableToTimeGrid()
+        f.SetInputDataObject(self.table)
+        f.SetDimensions(0, 1, 2, 3)
+        f.SetExtent(20, 2, 5, 2)
+        f.SetSpacing(5, 5, 5)
+        f.SetOrigin(3.3, 6.0, 7)
+        for t in range(2):
+            f.UpdateTimeStep(t)
+            ido = f.GetOutput()
+            checkme = [None] * len(self.arrs)
+            for i in range(len(self.arrs)):
+                a = self.arrs[i].reshape((20, 2, 5, 2))[:,:,:,t]
+                checkme[i] = a.flatten(order='F')
+            self.check_data_fidelity(ido, checkme)
+        return
+
+
+
+
+
+###############################################################################
+
 class TestReverseImageDataAxii(TestBase):
     """
     Test the `ReverseImageDataAxii` filter
@@ -492,6 +544,7 @@ NODATA_value  -9999
 ###############################################################################
 ###############################################################################
 if __name__ == '__main__':
+    import unittest
     unittest.main()
 ###############################################################################
 ###############################################################################


### PR DESCRIPTION
Added a new Table to Grid filter that can handle creating time series.

@tomtomatron, this should work for you!

**Demo:**

Create a 4D data array and save it to a file:

```py
import numpy as np

nt = 10
# create nx by ny by nz by nt data array
arr = np.zeros((100, 30, 5, nt))

for i in range(nt):
    arr[:,25,:,i] = 25*(i+1)
    arr[75,:,:,i] = 75*(i+1)

arr.tofile('data-4D.bin')
```

Now load it in ParaView using the *PVGeo: Packed Binaries Reader* with default settings. Then use the new *Table To Time Grid* under Filters->PVGeo: General Grids->Table To Time Grid and enter your extents. 

Note that this filter reshapes and input arrays to 4D. If your axii are out of order, then using the `Dimensions` field to change the axial ordering (default is x,y,z,t). The above file would create:


![ezgif com-video-to-gif](https://user-images.githubusercontent.com/22067021/46498059-99627f80-c7d9-11e8-9056-45e493c0120c.gif)
