### PR TITLE
Fix citation for PyVista

### DIFF
--- a/joss/paper.bib
+++ b/joss/paper.bib
@@ -56,7 +56,7 @@
     journal={ParaView},
 }
 
-@article{sullivan2019pyvista,
+@article{pyvista,
     doi = {10.21105/joss.01450},
     url = {https://doi.org/10.21105/joss.01450},
     year = {2019},


### PR DESCRIPTION
The key in the bibtex file didn't match the citation in the paper.

openjournals/joss-reviews#1451